### PR TITLE
Fix build with C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ endforeach()
 set(CMAKE_BUILD_TYPE "RELEASE")
 set(US_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED 1)
-set(CMAKE_CXX_STANDARD 11)
 
 # Since version 3.1, CMake pulls in implicit link libraries when compiling
 # source files in C mode. Because we mix C and C++ code in the test driver
@@ -365,10 +363,6 @@ if(MSVC)
   endforeach()
   set(US_CXX_FLAGS "/MP /WX ${US_CXX_FLAGS}")
 else()
-
-  if(US_COMPILER_APPLE_CLANG)
-    set(US_CXX_FLAGS "${US_CXX_FLAGS} -stdlib=libc++")
-  endif()
 
   # If not cross-compiling, turn on Stack Smashing Protection.
   # This is done in cases where libssp.so may not be available in the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ else()
     usFunctionCheckCompilerFlags(-fstack-protector-all US_CXX_FLAGS)
   endif()
 
-  foreach(_cxxflag  -Werror -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align
+  foreach(_cxxflag  -Wall -Wextra -Wpointer-arith -Winvalid-pch -Wcast-align
                     -Wwrite-strings -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast
                     -Wstrict-null-sentinel -Wsign-promo -fdiagnostics-show-option )
     usFunctionCheckCompilerFlags(${_cxxflag} US_CXX_FLAGS)

--- a/cmake/CMakeResourceDependencies.cpp
+++ b/cmake/CMakeResourceDependencies.cpp
@@ -20,12 +20,8 @@
 
 =============================================================================*/
 
-#include <iostream>
-
-namespace {
-
 // This is dummy code to silence some linkers warning about
 // empty object files.
-struct CMakeResourceDependencies { CMakeResourceDependencies() { std::cout << std::flush; } };
-
+int cppmicroservices_stub() {
+    return 0;
 }

--- a/cmake/GlobalConfig.h.in
+++ b/cmake/GlobalConfig.h.in
@@ -141,7 +141,7 @@ US_MSVC_DISABLE_WARNING(4996)
 #define US_HASH_FUNCTION_BEGIN(type)                         \
 namespace std {                                              \
 template<>                                                   \
-struct hash<type> : std::unary_function<type, std::size_t> { \
+struct hash<type> { \
 std::size_t operator()(const type& arg) const {
 
 #define US_HASH_FUNCTION_END } }; }

--- a/framework/src/service/ServiceListenerEntry.cpp
+++ b/framework/src/service/ServiceListenerEntry.cpp
@@ -32,7 +32,7 @@ US_MSVC_PUSH_DISABLE_WARNING(4180) // qualifier applied to function type has no 
 
 namespace cppmicroservices {
 
-struct ServiceListenerCompare : std::binary_function<ServiceListener, ServiceListener, bool>
+struct ServiceListenerCompare
 {
   bool operator()(const ServiceListener& f1,
                   const ServiceListener& f2) const


### PR DESCRIPTION
This fixes several build errors with CppMicroServices on contemporary macos.